### PR TITLE
Replace to aiohttp>=3.9.0,<3.9.1 in requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-aiohttp==3.9.1
-aiohttp==3.9.0
+aiohttp>=3.9.0,<3.9.1
 beautifulsoup4==4.12.2
 chromadb==0.4.20
 llama_hub==0.0.59


### PR DESCRIPTION
Instead of having the two version, change aiohttp>=3.9.0,<3.9.1 in requirement makes it install without error (from my side)